### PR TITLE
refactor: move bridgeProvider creation to factory

### DIFF
--- a/packages/sdk/config.ts
+++ b/packages/sdk/config.ts
@@ -1,8 +1,9 @@
+import { BaseBridgeProvider } from "./src/baseBridgeProvider"
 import { GlitterBridgeProvider } from "./src/glitterBridgeProvider"
 import { WormHoleBridgeProvider } from "./src/wormholeBridgeProvider"
 import { Asset, NetworkType } from "./types"
 
-export const BRIDGES = {
+export const BRIDGES: Record<string, new() => BaseBridgeProvider> = {
     'WormHole': WormHoleBridgeProvider,
     'Glitter': GlitterBridgeProvider
 }

--- a/packages/sdk/src/factory/bridgeProvider.ts
+++ b/packages/sdk/src/factory/bridgeProvider.ts
@@ -1,0 +1,18 @@
+import { BRIDGES } from "../../config";
+import { BaseBridgeProvider } from "../baseBridgeProvider";
+
+const bridgeProviderCache: Record<string, BaseBridgeProvider> = {};
+
+// Frontend will always call this function to create a bridgeProvider based on user selections
+// A cached bridgeProvider will be  returned  if already created  before for  efficiency
+export function getBridgeProvider(bridgeProviderId: string) {
+    if(bridgeProviderCache[bridgeProviderId]) return bridgeProviderCache[bridgeProviderId];
+    return createBridgeProvider(bridgeProviderId);
+}
+
+function createBridgeProvider(bridgeProviderId: string) {
+    const bridgeProvider = new BRIDGES[bridgeProviderId]();
+    bridgeProviderCache[bridgeProviderId] = bridgeProvider;
+
+    return bridgeProvider;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,33 +1,14 @@
-//@ts-nocheck
-import { BRIDGES } from "./config";
-
-const bridgeProviderCache = {};
-
-// Frontend will always call this function to create a bridgeProvider based on user selections
-// A cached bridgeProvider will be  returned  if already created  before for  efficiency
-export function getBridgeProvider(bridgeProviderId: string) {
-    if(bridgeProviderCache[bridgeId]) return bridgeProviderCache[bridgeProviderId];
-    return createBridgeProvider(bridgeProviderId);
-}
-
-function createBridgeProvider(bridgeProviderId: string) {
-    const bridgeProvider = new BRIDGES[bridgeProviderId]();
-    bridgeProviderCache[bridgeProviderId] = bridgeProvider;
-
-    return bridgeProvider;
-}
-
 // Combine the  supported  assets of all bridge providers and return it. This function is
-// beyond the scope of any particular bridge provider
-export function allSupportedNetworks() {
+
+import { NetworkType } from "../types";
+
+export function allSupportedChains(network: NetworkType) {
 
 }
 
-export function supportedAssetsByNetwork(network: string)  {
+export function supportedAssetsByChain(chain: string, network: NetworkType)  {
     
 }
-
-
 
 
 // ... Add other functions that frontend will need to call without using a specific bridge provider


### PR DESCRIPTION
Makes sense for those codes to be in the factory folder to separate concerns